### PR TITLE
Add command group to datadog tag

### DIFF
--- a/hystrix/circuit.go
+++ b/hystrix/circuit.go
@@ -12,6 +12,7 @@ import (
 // should be attempted, or rejected if the Health of the circuit is too low.
 type CircuitBreaker struct {
 	Name                   string
+	CommandGroup           string
 	open                   bool
 	forceOpen              bool
 	mutex                  *sync.RWMutex
@@ -69,6 +70,7 @@ func Flush() {
 func newCircuitBreaker(name string) *CircuitBreaker {
 	c := &CircuitBreaker{}
 	c.Name = name
+	c.CommandGroup = getSettings(name).CommandGroup
 	c.metrics = newMetricExchange(name)
 	c.executorPool = newBufferedExecutorPool(name)
 	c.mutex = &sync.RWMutex{}

--- a/hystrix/settings.go
+++ b/hystrix/settings.go
@@ -23,6 +23,7 @@ var (
 // Settings Setting for the hystrixCommand
 type Settings struct {
 	Timeout                     time.Duration
+	CommandGroup                string
 	MaxConcurrentRequests       int
 	RequestVolumeThreshold      uint64
 	SleepWindow                 time.Duration
@@ -32,11 +33,12 @@ type Settings struct {
 
 // CommandConfig is used to tune circuit settings at runtime
 type CommandConfig struct {
-	Timeout                int `json:"timeout"`
-	MaxConcurrentRequests  int `json:"max_concurrent_requests"`
-	RequestVolumeThreshold int `json:"request_volume_threshold"`
-	SleepWindow            int `json:"sleep_window"`
-	ErrorPercentThreshold  int `json:"error_percent_threshold"`
+	Timeout                int    `json:"timeout"`
+	CommandGroup           string `json:"command_group"`
+	MaxConcurrentRequests  int    `json:"max_concurrent_requests"`
+	RequestVolumeThreshold int    `json:"request_volume_threshold"`
+	SleepWindow            int    `json:"sleep_window"`
+	ErrorPercentThreshold  int    `json:"error_percent_threshold"`
 	// for more details refer - https://github.com/Netflix/Hystrix/wiki/Configuration#maxqueuesize
 	QueueSizeRejectionThreshold int `json:"queue_size_rejection_threshold"`
 }
@@ -91,8 +93,14 @@ func ConfigureCommand(name string, config CommandConfig) {
 		queueSizeRejectionThreshold = config.QueueSizeRejectionThreshold
 	}
 
+	groupName := name
+	if config.CommandGroup != "" {
+		groupName = config.CommandGroup
+	}
+
 	circuitSettings[name] = &Settings{
 		Timeout:                     time.Duration(timeout) * time.Millisecond,
+		CommandGroup:                groupName,
 		MaxConcurrentRequests:       max,
 		RequestVolumeThreshold:      uint64(volume),
 		SleepWindow:                 time.Duration(sleep) * time.Millisecond,

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -5,6 +5,7 @@ import (
 
 	// Developed on https://github.com/DataDog/datadog-go/tree/a27810dd518c69be741a7fd5d0e39f674f615be8
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/vermapratyush/hystrix-go/hystrix"
 	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
 )
 
@@ -108,10 +109,10 @@ func NewDatadogCollector(addr, prefix string) (func(string) metricCollector.Metr
 func NewDatadogCollectorWithClient(client DatadogClient) func(string) metricCollector.MetricCollector {
 
 	return func(name string) metricCollector.MetricCollector {
-
+		circuit, _, _ := hystrix.GetCircuit(name)
 		return &DatadogCollector{
 			client: client,
-			tags:   []string{"hystrixcircuit:" + name},
+			tags:   []string{"hystrixcircuit:" + circuit.Name, "commandGroup:" + circuit.CommandGroup},
 		}
 	}
 }

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
 	"github.com/rcrowley/go-metrics"
+	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
 )
 
 var makeTimerFunc = func() interface{} { return metrics.NewTimer() }

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
 	"github.com/cactus/go-statsd-client/statsd"
+	"github.com/vermapratyush/hystrix-go/hystrix/metric_collector"
 )
 
 // StatsdCollector fulfills the metricCollector interface allowing users to ship circuit


### PR DESCRIPTION
Use command group to group together a bunch of circuits together.
This is only used for reporting and monitoring (via datadog plugin)
https://github.com/Netflix/Hystrix/wiki/How-To-Use#command-group